### PR TITLE
Possibility to use custom paths for jpegtran binary

### DIFF
--- a/lib/JpegTran.js
+++ b/lib/JpegTran.js
@@ -55,7 +55,6 @@ JpegTran.prototype.write = function (chunk) {
                     return this._reportError(err);
                 }
                 this.commandLine = jpegTranBinaryPath + (this.jpegTranArgs ? ' ' + this.jpegTranArgs.join(' ') : ''); // For debugging
-                console.log(this.commandLine);
                 this.jpegTranProcess = childProcess.spawn(jpegTranBinaryPath, this.jpegTranArgs);
                 this.seenDataOnStdout = false;
 

--- a/lib/JpegTran.js
+++ b/lib/JpegTran.js
@@ -79,7 +79,7 @@ JpegTran.prototype.write = function (chunk) {
                 }.bind(this));
 
                 this.jpegTranProcess.stderr.on('data', function(chunk) {
-                    this._reportError(new Error(chunk.toString().trim()));
+                    this._error(new Error(chunk.toString().trim()));
                 }.bind(this));
 
                 this.jpegTranProcess.stdout.on('data', function (chunk) {

--- a/lib/JpegTran.js
+++ b/lib/JpegTran.js
@@ -1,10 +1,9 @@
 var childProcess = require('child_process'),
     Stream = require('stream').Stream,
     util = require('util'),
-    which = require('which'),
-    memoizeAsync = require('memoizeasync');
+    which = require('which');
 
-function JpegTran(jpegTranArgs) {
+function JpegTran(jpegTranArgs, jpegTranBinary) {
     Stream.call(this);
 
     this.jpegTranArgs = jpegTranArgs;
@@ -12,22 +11,30 @@ function JpegTran(jpegTranArgs) {
     this.writable = this.readable = true;
 
     this.hasEnded = false;
+
+    this.jpegBinary = jpegTranBinary;
 }
 
 util.inherits(JpegTran, Stream);
 
-JpegTran.getBinaryPath = memoizeAsync(function (cb) {
+JpegTran.prototype.getBinaryPath = function (defaultBinary, cb) {
+    if (defaultBinary) {
+        cb(null, defaultBinary);
+        return;
+    }
+
     which('jpegtran', function (err, jpegTranBinaryPath) {
         if (err) {
             jpegTranBinaryPath = require('jpegtran-bin');
         }
         if (jpegTranBinaryPath) {
+            this.jpegBinary = jpegTranBinaryPath;
             cb(null, jpegTranBinaryPath);
         } else {
             cb(new Error('No jpegtran binary in PATH and jpegtran-bin does not provide a pre-built binary for your architecture'));
         }
-    });
-});
+    }.bind(this));
+};
 
 JpegTran.prototype._reportError = function (err) {
     if (!this.hasEnded) {
@@ -42,13 +49,14 @@ JpegTran.prototype.write = function (chunk) {
     } else {
         if (!this.bufferedChunks) {
             this.bufferedChunks = [];
-            JpegTran.getBinaryPath(function (err, jpegTranBinaryPath) {
+            this.bufferedChunks.push(chunk);
+            JpegTran.prototype.getBinaryPath(this.jpegBinary, function(err, jpegTranBinaryPath) {
                 if (err) {
                     return this._reportError(err);
                 }
                 this.commandLine = jpegTranBinaryPath + (this.jpegTranArgs ? ' ' + this.jpegTranArgs.join(' ') : ''); // For debugging
+                console.log(this.commandLine);
                 this.jpegTranProcess = childProcess.spawn(jpegTranBinaryPath, this.jpegTranArgs);
-
                 this.seenDataOnStdout = false;
 
                 this.jpegTranProcess.on('error', this._reportError.bind(this));
@@ -62,6 +70,10 @@ JpegTran.prototype.write = function (chunk) {
                         this._reportError(new Error('The jpegtran process exited with a non-zero exit code: ' + exitCode));
                         this.hasEnded = true;
                     }
+                }.bind(this));
+
+                this.jpegTranProcess.stderr.on('data', function(chunk) {
+                    this._reportError(new Error(chunk.toString().trim()));
                 }.bind(this));
 
                 this.jpegTranProcess.stdout.on('data', function (chunk) {
@@ -82,7 +94,7 @@ JpegTran.prototype.write = function (chunk) {
                     this.jpegTranProcess.stdout.pause();
                 }
 
-                this.bufferedChunks.forEach(function (chunk) {
+                this.bufferedChunks.forEach( function(chunk) {
                     if (chunk === null) {
                         this.jpegTranProcess.stdin.end();
                     } else {
@@ -125,3 +137,4 @@ JpegTran.prototype.resume = function () {
 };
 
 module.exports = JpegTran;
+

--- a/lib/JpegTran.js
+++ b/lib/JpegTran.js
@@ -111,7 +111,6 @@ JpegTran.prototype.write = function (chunk) {
                 this.bufferedChunks = null;
             }.bind(this));
         }
-        this.bufferedChunks.push(chunk);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "jpegtran-bin": "=3.0.4",
-    "memoizeasync": "0.8.0",
     "which": "1.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
I've encountered a situation in which I needed to use two different jpegtran binaries in order to complete my task. I needed to be able to use both binaries during run-time (I am piping the output from one binary to the other), and changing the PATH can't be done in a clean way.

Don't know if anyone else needs this commit, but it would be very handy to have this for my case. 
